### PR TITLE
emacs: fix breakage under emacs-nox

### DIFF
--- a/emacs.d/init.el
+++ b/emacs.d/init.el
@@ -323,14 +323,15 @@
   (setq flycheck-indication-mode 'right-fringe
         flycheck-global-modes '(not c++-mode)
         flycheck-emacs-lisp-load-path 'inherit)
-  (define-fringe-bitmap 'flycheck-fringe-bitmap-double-arrow
-    (vector #b00010000
-            #b00110000
-            #b01110000
-            #b11110000
-            #b01110000
-            #b00110000
-            #b00010000))
+  (when window-system
+    (define-fringe-bitmap 'flycheck-fringe-bitmap-double-arrow
+      (vector #b00010000
+              #b00110000
+              #b01110000
+              #b11110000
+              #b01110000
+              #b00110000
+              #b00010000)))
   (global-flycheck-mode 1))
 
 (use-package prog-mode

--- a/emacs.d/lisp/config-looks.el
+++ b/emacs.d/lisp/config-looks.el
@@ -52,8 +52,10 @@
         spaceline-all-the-icons-flycheck-alternate t)
   (spaceline-all-the-icons-theme))
 
-(scroll-bar-mode -1)
-(horizontal-scroll-bar-mode -1)
+(when window-system
+  (scroll-bar-mode -1)
+  (horizontal-scroll-bar-mode -1))
+
 (tool-bar-mode -1)
 (menu-bar-mode -1)
 (blink-cursor-mode 1)


### PR DESCRIPTION
emacs-nox doesn't contain some functions which are present under Emacs compiled with GUI
support. These functions should not be called if we are running without a window system.