### PR TITLE
emacs: fix wrong font size on org mode

### DIFF
--- a/emacs.d/lisp/config-looks.el
+++ b/emacs.d/lisp/config-looks.el
@@ -23,7 +23,8 @@
   :config
   (load-theme 'doom-one t)
   (set-face-attribute 'vertical-border nil :background "#3f444a" :foreground "#3f444a")
-  (set-face-background 'mode-line-inactive (face-attribute 'mode-line :background)))
+  (set-face-background 'mode-line-inactive (face-attribute 'mode-line :background))
+  (doom-themes-org-config))
 
 (use-package diff-hl
   :defer t


### PR DESCRIPTION
https://github.com/hlissner/emacs-doom-themes/issues/93#issuecomment-319818822