### PR TITLE
emacs: use web-mode for .js files

### DIFF
--- a/emacs.d/init.el
+++ b/emacs.d/init.el
@@ -768,6 +768,7 @@ _M-p_: Unmark  _M-n_: Unmark  _q_: Quit"
   :ensure t
   :mode "\\.hbs\\'"
   :mode "\\.html\\'"
+  :mode "\\.js\\'"
   :config (setq web-mode-code-indent-offset 2
                 web-mode-markup-indent-offset 2
                 web-mode-css-indent-offset 2


### PR DESCRIPTION
web-mode seems to provide more modern syntax highlight than the default Javascript mode