### PR TITLE
emacs: fix my/git-link-homepage-in-browser

### DIFF
--- a/emacs.d/lisp/config-defuns.el
+++ b/emacs.d/lisp/config-defuns.el
@@ -228,6 +228,7 @@ Taken from http://endlessparentheses.com/emacs-narrow-or-widen-dwim.html"
 (defun my/git-link-homepage-in-browser ()
   "Open the repository homepage in the browser."
   (interactive)
+  (require 'git-link)
   (let ((git-link-open-in-browser t))
     (ignore git-link-open-in-browser)
     (call-interactively 'git-link-homepage)))


### PR DESCRIPTION
Since git-link is auto-loaded, the first call to my/git-link-homepage-in-browser loads the git-link
module after the let statement, which causes git-link-open-in-browser to be reset to its default
value. In order to solve this we have to make sure that the file is loaded before the let statement.