### PR TITLE
tmux: drop -u when calling choose-tree

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -24,7 +24,7 @@ bind-key C-y paste-buffer
 bind-key M-p pipe-pane -o 'cat >> tmux-rec.#h'
 unbind-key C-b
 bind-key ` select-pane -t :.+
-bind-key '"' choose-tree -u
+bind-key '"' choose-tree
 bind-key @ set-window-option synchronize-panes
 bind-key Tab last-window
 bind-key Enter send-prefix


### PR DESCRIPTION
This keybinding is mainly use for switching between sessions, not windows.