### PR TITLE
emacs: also indent the first line of the region

### DIFF
--- a/emacs.d/init.el
+++ b/emacs.d/init.el
@@ -414,7 +414,10 @@
          ("slashrc\\'" . python-mode))
   :bind (:map python-mode-map
               ("C-<f8>" . my/pylint-ignore-errors-at-point))
-  :config (unbind-key "C-c C-f" python-mode-map))
+  :config
+  (unbind-key "C-c C-f" python-mode-map)
+  (advice-add #'python-indent-shift-left :around #'my/python-shift-region)
+  (advice-add #'python-indent-shift-right :around #'my/python-shift-region))
 
 (use-package hy-mode
   :ensure t

--- a/emacs.d/lisp/config-defuns-autoloads.el
+++ b/emacs.d/lisp/config-defuns-autoloads.el
@@ -3,8 +3,8 @@
 ;;; Code:
 
 
-;;;### (autoloads nil "config-defuns" "config-defuns.el" (22930 52035
-;;;;;;  221222 578000))
+;;;### (autoloads nil "config-defuns" "config-defuns.el" (22942 55812
+;;;;;;  835539 948000))
 ;;; Generated autoloads from config-defuns.el
 
 (autoload 'my/cleanup-buffer "config-defuns" "\
@@ -239,6 +239,14 @@ Advice for commands with bad support for multiple cursors.  Call FN with ARGS in
 Update current file's autoloads and save.
 
 \(fn)" nil nil)
+
+(autoload 'my/python-shift-advise "config-defuns" "\
+Advice around Python shift functions.
+FN is the original function.  START is set interactivly to
+the line in which the beginning of the mark is found.  END and
+COUNT are set in the same way as the original function.
+
+\(fn FN START END &optional COUNT)" t nil)
 
 ;;;***
 

--- a/emacs.d/lisp/config-defuns.el
+++ b/emacs.d/lisp/config-defuns.el
@@ -244,14 +244,18 @@ Taken from http://endlessparentheses.com/emacs-narrow-or-widen-dwim.html"
           (kill-new file-name))
       (error "Buffer not visiting a file"))))
 
+(defun my/region-line-beginning ()
+  "Return the position of the line in which the region beginning is placed."
+  (save-excursion
+    (goto-char (region-beginning))
+    (line-beginning-position)))
+
 ;;;###autoload
 (defun my/indent-line-or-region ()
   "Indent region if it is active, otherwise indent line."
   (interactive)
   (if (region-active-p)
-      (let ((start (save-excursion
-                     (goto-char (region-beginning))
-                     (line-beginning-position))))
+      (let ((start (my/region-line-beginning)))
         (indent-region start (region-end))
         (setq deactivate-mark nil))
     (indent-according-to-mode)))
@@ -421,6 +425,18 @@ Taken from http://endlessparentheses.com/emacs-narrow-or-widen-dwim.html"
 (defun my/update-file-autoloads ()
   "Update current file's autoloads and save."
   (update-file-autoloads buffer-file-name t (format "%s-autoloads.el" (file-name-sans-extension buffer-file-name))))
+
+;;;###autoload
+(defun my/python-shift-region (fn start end &optional count)
+  "Advice around Python shift functions.
+FN is the original function.  START is set interactivly to
+the line in which the beginning of the mark is found.  END and
+COUNT are set in the same way as the original function."
+  (interactive
+   (if mark-active
+       (list (my/region-line-beginning) (region-end) current-prefix-arg)
+     (list (line-beginning-position) (line-end-position) current-prefix-arg)))
+  (apply fn start end count))
 
 (provide 'config-defuns)
 


### PR DESCRIPTION
This patch changes the behavior of Python's shift functions when the mark is active. The original
behavior does not indent the line in which the beginning of the region is placed. The advisement
makes sure that this line is also indented.