### PR TITLE
zsh: prepend the coreutils directory to PATH if exists

### DIFF
--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -180,6 +180,13 @@ WORDCHARS=${WORDCHARS//\/}
 READNULLCMD=less
 VIRTUAL_ENV_DISABLE_PROMPT=1
 
+() {
+    local COREUTILS_DIR=/usr/local/opt/coreutils/libexec/gnubin
+    if [[ -d $COREUTILS_DIR ]]; then
+        path=($COREUTILS_DIR "$path[@]")
+    fi
+}
+
 path=($HOME/bin $HOME/.cargo/bin "$path[@]" $HOME/.gem/ruby/*/bin(N))
 
 export EDITOR="/usr/bin/emacsclient -c"


### PR DESCRIPTION
macOS is bundled with BSD utilities, which do not support some of the flags being used in their
aliases.

The following paragraph is taken from the info of Homebrew's coreutils package:

All commands have been installed with the prefix 'g'.

If you really need to use these commands with their normal names, you
can add a "gnubin" directory to your PATH from your bashrc like:

    PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"

Additionally, you can access their man pages with normal names if you add
the "gnuman" directory to your MANPATH from your bashrc as well:

    MANPATH="/usr/local/opt/coreutils/libexec/gnuman:$MANPATH"