### PR TITLE
emacs: use js2-mode for Javascript files

### DIFF
--- a/emacs.d/init.el
+++ b/emacs.d/init.el
@@ -783,12 +783,15 @@ _M-p_: Unmark  _M-n_: Unmark  _q_: Quit"
   :ensure
   :mode "\\.hbs\\'"
   :mode "\\.html\\'"
-  :mode "\\.js\\'"
   :config (setq web-mode-code-indent-offset 2
                 web-mode-markup-indent-offset 2
                 web-mode-css-indent-offset 2
                 web-mode-style-padding 2
                 web-mode-script-padding 2))
+
+(use-package js2-mode
+  :ensure
+  :mode "\\.js\\'")
 
 (use-package winner
   :config (winner-mode))


### PR DESCRIPTION
As it turns out, web-mode isn't designed to be used in Javascript files. For example, it does not
even provide a Flychecker checker for Javascript.